### PR TITLE
downstream: fix bundle generation

### DIFF
--- a/Makefile.Downstream.mk
+++ b/Makefile.Downstream.mk
@@ -55,6 +55,7 @@ bundle: kustomize operator-sdk manifests
 	rm -f config/manifests/kustomization.yaml
 	mkdir -p build dist
 	cd build && echo "$$BUILD_INSTALLER_OVERLAY" > kustomization.yaml
+	cd build && $(KUSTOMIZE) edit add resource ../config/default/
 	cd config/manifests/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)"
 	cd config/manifests && $(KUSTOMIZE) create --resources bases,../../build
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle \

--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2024-08-20T14:06:06Z"
+    createdAt: "2024-09-05T09:21:50Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -700,7 +700,6 @@ spec:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
                 - --v=0
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
                 name: kube-rbac-proxy
@@ -720,6 +719,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -759,6 +759,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: ceph-csi-controller-manager

--- a/bundle/manifests/csi.ceph.io_drivers.yaml
+++ b/bundle/manifests/csi.ceph.io_drivers.yaml
@@ -3466,8 +3466,8 @@ spec:
                 description: |-
                   OMAP generator will generate the omap mapping between the PV name and the RBD image.
                   Need to be enabled when we are using rbd mirroring feature.
-                  By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                  it set it to false.
+                  By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                  it set it to true.
                 type: boolean
               grpcTimeout:
                 description: Set the gRPC timeout for gRPC call issued by the driver
@@ -3542,11 +3542,14 @@ spec:
                     description: log rotation for csi pods
                     properties:
                       logHostPath:
-                        description: LogHostPath is the prefix directory path for
-                          the csi log files
+                        description: |-
+                          LogHostPath is the prefix directory path for the csi log files
+                          Default to /var/lib/cephcsi
                         type: string
                       maxFiles:
-                        description: MaxFiles is the number of logrtoate files
+                        description: |-
+                          MaxFiles is the number of logrtoate files
+                          Default to 7
                         type: integer
                       maxLogSize:
                         anyOf:
@@ -3565,6 +3568,9 @@ spec:
                         - monthly
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: Either maxLogSize or periodicity must be set
+                      rule: (has(self.maxLogSize)) || (has(self.periodicity))
                   verbosity:
                     description: |-
                       Log verbosity level for driver pods,

--- a/bundle/manifests/csi.ceph.io_operatorconfigs.yaml
+++ b/bundle/manifests/csi.ceph.io_operatorconfigs.yaml
@@ -3505,8 +3505,8 @@ spec:
                     description: |-
                       OMAP generator will generate the omap mapping between the PV name and the RBD image.
                       Need to be enabled when we are using rbd mirroring feature.
-                      By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                      it set it to false.
+                      By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                      it set it to true.
                     type: boolean
                   grpcTimeout:
                     description: Set the gRPC timeout for gRPC call issued by the
@@ -3581,11 +3581,14 @@ spec:
                         description: log rotation for csi pods
                         properties:
                           logHostPath:
-                            description: LogHostPath is the prefix directory path
-                              for the csi log files
+                            description: |-
+                              LogHostPath is the prefix directory path for the csi log files
+                              Default to /var/lib/cephcsi
                             type: string
                           maxFiles:
-                            description: MaxFiles is the number of logrtoate files
+                            description: |-
+                              MaxFiles is the number of logrtoate files
+                              Default to 7
                             type: integer
                           maxLogSize:
                             anyOf:
@@ -3605,6 +3608,9 @@ spec:
                             - monthly
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: Either maxLogSize or periodicity must be set
+                          rule: (has(self.maxLogSize)) || (has(self.periodicity))
                       verbosity:
                         description: |-
                           Log verbosity level for driver pods,


### PR DESCRIPTION
In https://github.com/ceph/ceph-csi-operator/pull/125 we did remove BUILD_INSTALLER_OVERLAY from the var and adding it in the required targets, This PR adopts downstream for the same and pushed the latest bundle changes


/assign @iamniting 