### PR TITLE
Bug 2313203:[release-4.17] add missing rbac for persistentvolume during deletion 

### DIFF
--- a/Makefile.Downstream.mk
+++ b/Makefile.Downstream.mk
@@ -1,3 +1,9 @@
+# defining variables here before including "Makefile" makes these variables unique for current makefile
+IMAGE_REGISTRY ?= quay.io
+REGISTRY_NAMESPACE ?= ocs-dev
+IMAGE_TAG ?= latest
+IMAGE_NAME ?= cephcsi-operator
+
 include Makefile
 
 BUNDLE_IMAGE_NAME ?= $(IMAGE_NAME)-bundle

--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2024-08-20T14:06:06Z"
+    createdAt: "2024-09-18T13:53:48Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -57,6 +57,7 @@ spec:
           - create
           - delete
           - patch
+          - update
         - apiGroups:
           - ""
           resources:
@@ -498,6 +499,7 @@ spec:
           - create
           - delete
           - patch
+          - update
         - apiGroups:
           - ""
           resources:

--- a/bundle/manifests/csi.ceph.io_clientprofilemappings.yaml
+++ b/bundle/manifests/csi.ceph.io_clientprofilemappings.yaml
@@ -40,23 +40,31 @@ spec:
           spec:
             description: ClientProfileMappingSpec defines the desired state of ClientProfileMapping
             properties:
-              mappings:
+              blockPoolMapping:
                 items:
-                  description: MappingsSpec define a mapping between a local and remote
-                    profiles
+                  description: BlockPoolMappingSpec define a mapiing between a local
+                    and remote block pools
                   properties:
-                    blockPoolIdMapping:
-                      items:
-                        items:
+                    local:
+                      description: BlockPoolRefSpec identify a blockpool - client
+                        profile pair
+                      properties:
+                        clientProfileName:
                           type: string
-                        maxItems: 2
-                        minItems: 2
-                        type: array
-                      type: array
-                    localClientProfile:
-                      type: string
-                    remoteClientProfile:
-                      type: string
+                        poolId:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    remote:
+                      description: BlockPoolRefSpec identify a blockpool - client
+                        profile pair
+                      properties:
+                        clientProfileName:
+                          type: string
+                        poolId:
+                          minimum: 0
+                          type: integer
+                      type: object
                   type: object
                 type: array
             type: object

--- a/bundle/manifests/csi.ceph.io_drivers.yaml
+++ b/bundle/manifests/csi.ceph.io_drivers.yaml
@@ -3542,11 +3542,14 @@ spec:
                     description: log rotation for csi pods
                     properties:
                       logHostPath:
-                        description: LogHostPath is the prefix directory path for
-                          the csi log files
+                        description: |-
+                          LogHostPath is the prefix directory path for the csi log files
+                          Default to /var/lib/cephcsi
                         type: string
                       maxFiles:
-                        description: MaxFiles is the number of logrtoate files
+                        description: |-
+                          MaxFiles is the number of logrtoate files
+                          Default to 7
                         type: integer
                       maxLogSize:
                         anyOf:
@@ -3565,6 +3568,9 @@ spec:
                         - monthly
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: Either maxLogSize or periodicity must be set
+                      rule: (has(self.maxLogSize)) || (has(self.periodicity))
                   verbosity:
                     description: |-
                       Log verbosity level for driver pods,

--- a/bundle/manifests/csi.ceph.io_operatorconfigs.yaml
+++ b/bundle/manifests/csi.ceph.io_operatorconfigs.yaml
@@ -3581,11 +3581,14 @@ spec:
                         description: log rotation for csi pods
                         properties:
                           logHostPath:
-                            description: LogHostPath is the prefix directory path
-                              for the csi log files
+                            description: |-
+                              LogHostPath is the prefix directory path for the csi log files
+                              Default to /var/lib/cephcsi
                             type: string
                           maxFiles:
-                            description: MaxFiles is the number of logrtoate files
+                            description: |-
+                              MaxFiles is the number of logrtoate files
+                              Default to 7
                             type: integer
                           maxLogSize:
                             anyOf:
@@ -3605,6 +3608,9 @@ spec:
                             - monthly
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: Either maxLogSize or periodicity must be set
+                          rule: (has(self.maxLogSize)) || (has(self.periodicity))
                       verbosity:
                         description: |-
                           Log verbosity level for driver pods,

--- a/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "patch", "update"]

--- a/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]


### PR DESCRIPTION
manual cherry-pick of #31, changes are u/s `deploy` folder content will be mostly incorrect and so removed that and ran `make bundle -f Makefile.Downstream.mk` to pick changes in the corresponding (release-4.17) branch.