### PR TITLE
update csv timestamp only when required in bundle

### DIFF
--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -1,0 +1,31 @@
+name: downstream
+on:
+  pull_request:
+    branches:
+      - main
+      - release-*
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bundle:
+    name: build-bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: build bundle
+        run: |
+          make -f Makefile.Downstream.mk bundle
+          msg='Uncommitted bundle changes. Run `make -f Makefile.Downstream.mk bundle` and commit results.'
+          git diff --exit-code bundle || (echo -e '\e[31m'"$msg"; exit 1)

--- a/Makefile.Downstream.mk
+++ b/Makefile.Downstream.mk
@@ -67,6 +67,7 @@ bundle: kustomize operator-sdk manifests
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle \
 		--overwrite --manifests --metadata --package $(PACKAGE_NAME) --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS) \
 		--extra-service-accounts $(EXTRA_SERVICE_ACCOUNTS)
+	hack/update-csv-timestamp.sh
 	rm -rf build
 
 .PHONY: bundle-build

--- a/hack/update-csv-timestamp.sh
+++ b/hack/update-csv-timestamp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git diff --quiet -I'^( )+createdAt: ' bundle
+if ((! $?)) ; then
+    git checkout --quiet bundle
+fi


### PR DESCRIPTION
This PR includes the following changes

add a script not to update the timestamp in the csv if there are no bundle changes add ci action to verify bundle changes

With operator-sdk 1.26+ every time we generate a new bundle, the createdAt field in the csv is updated.
This means we have to create a manual backport even when there are no bundle changes hence, resetting the createdAt field if there are no changes in the bundle.

This PR also introduces a ci action to check whether there are any uncommitted bundle changes.

Reference from https://github.com/red-hat-storage/ocs-client-operator/pull/199

