### PR TITLE
add ocs default toleration to csi-op podspec

### DIFF
--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2024-09-18T12:32:51Z"
+    createdAt: "2024-10-04T03:16:54Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -766,6 +766,11 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: ceph-csi-controller-manager
               terminationGracePeriodSeconds: 10
+              tolerations:
+              - effect: NoSchedule
+                key: node.ocs.openshift.io/storage
+                operator: Equal
+                value: "true"
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -96,3 +96,8 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -15289,3 +15289,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: ceph-csi-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"

--- a/deploy/multifile/operator.yaml
+++ b/deploy/multifile/operator.yaml
@@ -659,3 +659,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: ceph-csi-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"


### PR DESCRIPTION
all components deployed as part of odf should tolerate this taint by default "node.ocs.openshift.io/storage=true:NoSchedule"