### PR TITLE
Bug 2315651:[release-4.17] add ocs default toleration to csi-op podspec

### DIFF
--- a/.github/workflows/test_operator.yaml
+++ b/.github/workflows/test_operator.yaml
@@ -42,7 +42,6 @@ jobs:
 
       - name: print k8s cluster status
         run: |
-            minikube status
             kubectl get nodes
 
       - name: use local disk

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dist/
 
 # Locally generated dockerfile for multi-arch
 Dockerfile.cross
+
+deploy/all-in-one/install.yaml
+deploy/multifile/operator.yaml

--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2024-09-18T13:53:48Z"
+    createdAt: "2024-10-04T07:50:06Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -765,6 +765,11 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: ceph-csi-controller-manager
               terminationGracePeriodSeconds: 10
+              tolerations:
+              - effect: NoSchedule
+                key: node.ocs.openshift.io/storage
+                operator: Equal
+                value: "true"
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -95,3 +95,8 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"


### PR DESCRIPTION
all components deployed as part of odf should tolerate this taint by default "node.ocs.openshift.io/storage=true:NoSchedule"

manual cherry-pick of #37 