### PR TITLE
ci: disable dependabot in downstream

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   # Dependencies listed in go.mod
   - package-ecosystem: "gomod"
     directory: "/" # Location of package manifests
+     # ODF only: disable PR creation, dependencies are synced from upstream
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
     groups:
@@ -21,5 +23,7 @@ updates:
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"
     directory: "/"
+    # ODF only: disable PR creation, dependencies are synced from upstream
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This is downstream only committed to disable dependabot. This is similar to https://github.com/red-hat-storage/ceph-csi/pull/28

cc @Nikhil-Ladha 