### PR TITLE
DFBUGS-1145: Update externalsnapshotter volumegroupsnapshot container arg

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -31,7 +31,7 @@ var imageDefaults = map[string]string{
 	"provisioner": "registry.k8s.io/sig-storage/csi-provisioner:v5.0.1",
 	"attacher":    "registry.k8s.io/sig-storage/csi-attacher:v4.6.1",
 	"resizer":     "registry.k8s.io/sig-storage/csi-resizer:v1.11.1",
-	"snapshotter": "registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1",
+	"snapshotter": "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0",
 	"registrar":   "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.11.1",
 	"plugin":      "quay.io/cephcsi/cephcsi:v3.12.2",
 	"addons":      "quay.io/csiaddons/k8s-sidecar:v0.10.0",

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -368,7 +368,7 @@ var PreventVolumeModeConversionContainerArg = "--prevent-volume-mode-conversion=
 var HonorPVReclaimPolicyContainerArg = "--feature-gates=HonorPVReclaimPolicy=true"
 var ImmediateTopologyContainerArg = "--immediate-topology=false"
 var RecoverVolumeExpansionFailureContainerArg = "--feature-gates=RecoverVolumeExpansionFailure=true"
-var EnableVolumeGroupSnapshotsContainerArg = "--enable-volume-group-snapshots=true"
+var EnableVolumeGroupSnapshotsContainerArg = "--feature-gates=CSIVolumeGroupSnapshot=true"
 var ForceCephKernelClientContainerArg = "--forcecephkernelclient=true"
 var LogToStdErrContainerArg = "--logtostderr=false"
 var AlsoLogToStdErrContainerArg = "--alsologtostderr=true"


### PR DESCRIPTION
This is a backport of https://github.com/ceph/ceph-csi-operator/pull/179.

Note:- Keeping it on hold until the downstream main is synced with upstream main

/hold 