### PR TITLE
DFBUGS-848: [release-4.18] csi: update RBACs for CSIAddonsNode

### DIFF
--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-01-07T09:56:41Z"
+    createdAt: "2025-02-18T09:22:36Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -862,6 +862,8 @@ spec:
           - csiaddonsnodes
           verbs:
           - get
+          - watch
+          - list
           - create
           - update
           - delete
@@ -936,6 +938,8 @@ spec:
           - csiaddonsnodes
           verbs:
           - get
+          - watch
+          - list
           - create
           - update
           - delete
@@ -966,6 +970,8 @@ spec:
           - csiaddonsnodes
           verbs:
           - get
+          - watch
+          - list
           - create
           - update
           - delete

--- a/config/csi-rbac/cephfs_ctrlplugin_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/config/csi-rbac/rbd_ctrlplugin_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/config/csi-rbac/rbd_nodeplugin_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -14098,6 +14098,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -14185,6 +14187,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -14220,6 +14224,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -57,6 +57,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -103,6 +105,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -138,6 +142,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete


### PR DESCRIPTION
This patch adds list and watch verbs to cephfs and rbd provisioners that are required to recreate the csiaddosnode object when they are deleted under unwanted circumferences. This is required for csi-addos to work properly after https://github.com/csi-addons/kubernetes-csi-addons/pull/765 is merged same changes are made in cephcsi operator as well https://github.com/ceph/ceph-csi-operator/pull/204



@black-dragon74 please add the Jira number to the PR title to get this PR merged