### PR TITLE
bundle: Add replaces option to the bundle

### DIFF
--- a/Makefile.Downstream.mk
+++ b/Makefile.Downstream.mk
@@ -66,10 +66,13 @@ bundle: kustomize operator-sdk manifests
 	cd build && $(KUSTOMIZE) edit add resource ../config/default/
 	cd build && $(KUSTOMIZE) edit add patch --path manager_downstream_tolerations.yaml --kind Deployment --name controller-manager
 	cd config/manifests/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)"
+	cd config/manifests/bases && $(KUSTOMIZE) edit add patch --name cephcsi-operator.v0.1.1 --kind ClusterServiceVersion\
+		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'
 	cd config/manifests && $(KUSTOMIZE) create --resources bases,../../build
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle \
 		--overwrite --manifests --metadata --package $(PACKAGE_NAME) --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS) \
 		--extra-service-accounts $(EXTRA_SERVICE_ACCOUNTS)
+	cd config/manifests/bases && yq -i 'del(.patches)' kustomization.yaml
 	hack/update-csv-timestamp.sh
 	rm -rf build
 

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cephcsi-operator.clusterserviceversion.yaml
+  - cephcsi-operator.clusterserviceversion.yaml
 commonAnnotations:
   olm.skipRange: ""


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch adds the missing replaces option in
the operator bundle.

## Is there anything that requires special attention ##

Do we need to mirror any of these (gitignore,manifest rename) changes to upstream?