### PR TITLE
DFBUGS-3992: [release-4.20] rbac: include the role and rolebinding for CephFS nodeplugin

### DIFF
--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-07-30T08:02:48Z"
+    createdAt: "2025-09-22T11:01:49Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -948,6 +948,38 @@ spec:
           verbs:
           - update
         serviceAccountName: ceph-csi-cephfs-ctrlplugin-sa
+      - rules:
+        - apiGroups:
+          - csiaddons.openshift.io
+          resources:
+          - csiaddonsnodes
+          verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          - daemonsets/finalizers
+          verbs:
+          - update
+        serviceAccountName: ceph-csi-cephfs-nodeplugin-sa
       - rules:
         - apiGroups:
           - ""

--- a/config/csi-rbac/kustomization.yaml
+++ b/config/csi-rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - cephfs_nodeplugin_service_account.yaml
 - cephfs_nodeplugin_cluster_role.yaml
 - cephfs_nodeplugin_cluster_role_binding.yaml
+- cephfs_nodeplugin_role.yaml
+- cephfs_nodeplugin_role_binding.yaml
 - nfs_ctrlplugin_cluster_role.yaml
 - nfs_ctrlplugin_cluster_role_binding.yaml
 - nfs_ctrlplugin_service_account.yaml

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -28519,6 +28519,43 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+  namespace: ceph-csi-operator-system
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: ceph-csi-operator
@@ -29733,6 +29770,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ceph-csi-operator-cephfs-ctrlplugin-sa
+  namespace: ceph-csi-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-rb
+  namespace: ceph-csi-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: ceph-csi-operator-cephfs-nodeplugin-sa
   namespace: ceph-csi-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -1,0 +1,46 @@
+{{- $root := . -}}
+{{- $driver := .Values.drivers.cephfs -}}
+{{- if $driver.enabled }}
+{{- $normalizedDriverName := include "normalizeDriverName" $driver.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $normalizedDriverName }}-nodeplugin-r
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+{{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -1,0 +1,17 @@
+{{- $root := . -}}
+{{- $driver := .Values.drivers.cephfs -}}
+{{- if $driver.enabled }}
+{{- $normalizedDriverName := include "normalizeDriverName" $driver.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $normalizedDriverName }}-nodeplugin-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $normalizedDriverName }}-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: {{ $normalizedDriverName }}-nodeplugin-sa
+  namespace: {{ $root.Release.Namespace }}
+{{- end }}

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-r
+  labels:
+  {{- include "ceph-csi-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-rb
+  labels:
+  {{- include "ceph-csi-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-r'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-sa'
+  namespace: '{{ .Release.Namespace }}'

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -85,6 +85,43 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+  namespace: ceph-csi-operator-system
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: ceph-csi-operator-rbd-ctrlplugin-r
   namespace: ceph-csi-operator-system
 rules:
@@ -872,6 +909,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ceph-csi-operator-cephfs-ctrlplugin-sa
+  namespace: ceph-csi-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-rb
+  namespace: ceph-csi-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: ceph-csi-operator-cephfs-nodeplugin-sa
   namespace: ceph-csi-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Without the RBAC for accessing Pods and other resources, the CephFS
nodeplugin can not successfully run the CSI-Addons sidecar/Pod.
