### PR TITLE
DFBUGS-4259: [release-4.20] deploy: Add watch permission for Secrets to CephFS ctrlplugin

### DIFF
--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-09-22T11:01:49Z"
+    createdAt: "2025-09-30T07:40:12Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -61,6 +61,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -28741,6 +28741,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -14,6 +14,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -216,6 +216,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch adds watch permission for Secrets to CephFS control plugin cluster role.

Required by: https://github.com/ceph/ceph-csi/pull/5497

(cherry picked from commit https://github.com/red-hat-storage/ceph-csi-operator/commit/5f0a856902f08c14bde7efafde192a002163b189)

