### PR TITLE
[release-4.19] Bump go (stdlib) from 1.23.0 to 1.23.1

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi-operator/api
 
-go 1.23.0
+go 1.23.1
 
 require (
 	k8s.io/api v0.32.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi-operator
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-00010101000000-000000000000

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/blang/semver/v4
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
 # github.com/ceph/ceph-csi-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.23.0
+## explicit; go 1.23.1
 github.com/ceph/ceph-csi-operator/api/v1alpha1
 # github.com/cespare/xxhash/v2 v2.3.0
 ## explicit; go 1.11


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `api/go.mod`)
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `go.mod`)
