### PR TITLE
[release-4.20] Bump go (stdlib) from 1.24.0 to 1.24.2

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi-operator/api
 
-go 1.24.0
+go 1.24.2
 
 require (
 	k8s.io/api v0.33.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi-operator
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-00010101000000-000000000000

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/blang/semver/v4
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
 # github.com/ceph/ceph-csi-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.24.0
+## explicit; go 1.24.2
 github.com/ceph/ceph-csi-operator/api/v1
 github.com/ceph/ceph-csi-operator/api/v1alpha1
 # github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.0` → `1.24.2` (in `api/go.mod`)
- **go (stdlib)**: `1.24.0` → `1.24.2` (in `go.mod`)
