### PR TITLE
[release-4.22] Bump go (stdlib) from 1.25.0 to 1.25.6

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi-operator/api
 
-go 1.25.0
+go 1.25.6
 
 require (
 	k8s.io/api v0.35.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi-operator
 
-go 1.25.0
+go 1.25.6
 
 require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-20260211052505-60308e55e5d9

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/blang/semver/v4
 ## explicit; go 1.23
 github.com/cenkalti/backoff/v5
 # github.com/ceph/ceph-csi-operator/api v0.0.0-20260211052505-60308e55e5d9 => ./api
-## explicit; go 1.25.0
+## explicit; go 1.25.6
 github.com/ceph/ceph-csi-operator/api/v1
 github.com/ceph/ceph-csi-operator/api/v1alpha1
 # github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.0` → `1.25.6` (in `api/go.mod`)
- **go (stdlib)**: `1.25.0` → `1.25.6` (in `go.mod`)
