### PR TITLE
Add scc annotions to ceph-csi pods

### DIFF
--- a/Makefile.Downstream.mk
+++ b/Makefile.Downstream.mk
@@ -65,10 +65,12 @@ bundle: kustomize operator-sdk manifests
 	@# as per kustomize patch files should be in the folder and subfolders of kustomization.yaml for security reasons
 	cp config/manager/downstream_tolerations.yaml build/manager_downstream_tolerations.yaml
 	cp config/manager/manager_priority_class_patch.yaml build/manager_priority_class_patch.yaml
+	cp config/manager/manager_required_scc_patch.yaml build/manager_required_scc_patch.yaml
 	cd build && echo "$$BUILD_INSTALLER_OVERLAY" > kustomization.yaml
 	cd build && $(KUSTOMIZE) edit add resource ../config/default/
 	cd build && $(KUSTOMIZE) edit add patch --path manager_downstream_tolerations.yaml --kind Deployment --name controller-manager
 	cd build && $(KUSTOMIZE) edit add patch --path manager_priority_class_patch.yaml
+	cd build && $(KUSTOMIZE) edit add patch --path manager_required_scc_patch.yaml
 	cd config/manifests/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)"
 	cd config/manifests/bases && $(KUSTOMIZE) edit add patch --name cephcsi-operator.v0.1.1 --kind ClusterServiceVersion\
 		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'

--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -1116,6 +1116,7 @@ spec:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
+                openshift.io/required-scc: restricted-v2
               labels:
                 control-plane: ceph-csi-op-controller-manager
             spec:

--- a/config/manager/manager_required_scc_patch.yaml
+++ b/config/manager/manager_required_scc_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2


### PR DESCRIPTION
## What this PR does
Solves : https://redhat.atlassian.net/browse/RHSTOR-8757
Related PR: https://github.com/red-hat-storage/ocs-client-operator/pull/666
Adds the `openshift.io/required-scc: restricted-v2` annotation to the ceph-csi-operator manager (`controller-manager`) Deployment pod template so OpenShift SCC admission pins the operator pod to the `restricted-v2` SCC.

Changes:

1. **`config/openshift/manager_required_scc_patch.yaml`** — kustomize patch that sets the required-SCC annotation on the manager pod template.
2. **`config/openshift/kustomization.yaml`** — applies the patch for `make build-openshift-installer`.
3. **`Makefile.Downstream.mk`** — stages and applies the patch in the downstream `bundle` target (alongside existing tolerations and priority-class patches) so the annotation is included in the generated CSV.
4. **Regenerated artifacts** — `bundle/manifests/cephcsi-operator.clusterserviceversion.yaml` and `deploy/all-in-one/install-openshift.yaml`.

## Context for the reviewer

OpenShift is rolling out SCC pinning for core/platform workloads via the `openshift.io/required-scc` pod template annotation. This prevents a workload from being assigned a different SCC when multiple SCCs match, which can cause unexpected privilege changes.

The ceph-csi-operator manager runs as a non-privileged Deployment and is expected to use `restricted-v2` on ODF/OpenShift. This PR declares that explicitly in the deployment manifest and downstream OLM bundle.

This is the ceph-csi-operator half of a broader change. The companion work in **ocs-client-operator** adds `openshift.io/required-scc: ceph-csi-op-scc` to CSI controller/node plugin pods via the `OperatorConfig` template, since those pods require the custom privileged SCC.

## Is there anything that requires special attention?

- **SCC must exist and be usable:** Admission fails if `restricted-v2` is missing or the operator service account lacks `use` permission on it. On ODF/OpenShift this should already hold for the manager pod.
- **Patch placement:** The patch lives under `config/openshift/` (used by the OpenShift overlay and copied into the bundle build staging dir), consistent with the overlay used by `make build-openshift-installer`.
- **Bundle regeneration:** The CSV and `install-openshift.yaml` diffs are build outputs; confirm they only add the annotation and expected timestamp updates.
- **No runtime/controller logic changes:** This is manifest/kustomize/Makefile-only.

## Is the change backward compatible?

**Yes.** This only adds a pod template metadata annotation. It does not change container images, commands, RBAC, SCC definitions, or operator reconciliation logic.

Existing clusters where the manager already runs under `restricted-v2` should see no functional change — the annotation makes the intended SCC explicit rather than relying on implicit SCC selection.

## Are there concerns around backward compatibility?

Low risk in the intended ODF/OpenShift downstream environment. The main failure mode is admission rejection if:

- `restricted-v2` is unavailable (non-OpenShift or very old clusters), or
- the operator service account cannot `use` `restricted-v2`.

That matches OpenShift’s documented behavior for required-SCC annotations and is the intended trade-off for pinning.

## External context

- [OpenShift docs: Managing SCCs — required SCC annotation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/authentication_and_authorization/managing-pod-security-policies)
- [OpenShift enhancement: Custom SCC preemption prevention](https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md)
- OpenShift API constant: `security.openshift.io/required-scc` (`RequiredSCCAnnotation` in `github.com/openshift/api/security/v1`)


## Future concerns

- **CSI driver pods:** SCC pinning for RBD/CephFS/NFS controller and node plugin pods is handled separately via ocs-client-operator’s `OperatorConfig` template (`ceph-csi-op-scc`), not in this PR.
- **Helm chart path:** The Helm-based install path (`config/helm/`) is unchanged; evaluate whether Helm values/templates should carry the same annotation for consistency.


## Test plan

- [x] `make -f Makefile.Downstream.mk bundle` succeeds
- [x] Generated CSV Deployment spec includes `openshift.io/required-scc: restricted-v2`
- [x] `make build-openshift-installer` succeeds
- [ ] `deploy/all-in-one/install-openshift.yaml` includes the annotation on the manager pod template

---
