### PR TITLE
build: replace unavailable kube-rbac-proxy image with docker.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WATCH_NAMESPACE ?= ""
 
 IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-KUBE_RBAC_PROXY_IMG ?= registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
+KUBE_RBAC_PROXY_IMG ?= docker.io/kubebuilder/kube-rbac-proxy:v0.16.0
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0

--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -703,7 +703,7 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --v=0
-                image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                image: docker.io/kubebuilder/kube-rbac-proxy:v0.16.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -15173,7 +15173,7 @@ spec:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --v=0
-        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: docker.io/kubebuilder/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/multifile/operator.yaml
+++ b/deploy/multifile/operator.yaml
@@ -528,7 +528,7 @@ spec:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --v=0
-        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: docker.io/kubebuilder/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
## Summary
- Replace `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0` with `docker.io/kubebuilder/kube-rbac-proxy:v0.16.0` in the Makefile, CSV, and deploy manifests.
- Unblocks ocs-operator CI on `release-4.18`, which has been failing for a long time at the ceph-csi-operator install phase with `ImagePullBackOff`.

## Why
Kubebuilder deprecated and removed hosting of `kube-rbac-proxy` images. This branch previously moved from `gcr.io/kubebuilder/...` to `registry.k8s.io/kubebuilder/...`, but that mirror also no longer serves the image. Pulls fail with `manifest unknown`, so the kube-rbac-proxy sidecar never starts.

That failure surfaces in ocs-operator e2e/CI when it installs the ceph-csi-operator bundle (`operator-sdk run bundle`), for example:

```text
Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0":
manifest unknown: Failed to fetch "v0.16.0"
Error: ErrImagePull / ImagePullBackOff
```

(and equivalently for `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0` on this branch)

`docker.io/kubebuilder/kube-rbac-proxy:v0.16.0` is still available and is the correct replacement.

## Why not ICSP / ITMS
- **ICSP** only remaps **digest**-based pulls. These pods pull by **tag**, so ICSP does not help.
- **ImageTagMirrorSet** can remap tag pulls, but applying it causes the Machine Config Operator to drain/update nodes to rewrite `registries.conf`, which is too heavy and disruptive for CI.
- Patching Deployments after install also fails because OLM reconciles them back from the CSV.

Changing the image in the Makefile/CSV/deploy manifests is the durable fix for this release branch.

## Test plan
- [ ] Confirm `docker.io/kubebuilder/kube-rbac-proxy:v0.16.0` pulls successfully
- [ ] Confirm `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0` still fails (documents why the prior mirror change is insufficient)
- [ ] Install/rebuild the bundle and verify the CSV/deploy manifests reference `docker.io/...`
- [ ] Re-run ocs-operator CI against release-4.18 and confirm ceph-csi-operator install no longer hits ImagePullBackOff on kube-rbac-proxy


Made with [Cursor](https://cursor.com)