### PR TITLE
NO-ISSUE: [release-4.17] Update kube-rbac-proxy to use registry.k8s.io mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WATCH_NAMESPACE ?= ""
 
 IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-KUBE_RBAC_PROXY_IMG ?= gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+KUBE_RBAC_PROXY_IMG ?= registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0

--- a/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cephcsi-operator.clusterserviceversion.yaml
@@ -704,7 +704,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
## Summary
- Replace `gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0` with `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0` in the Makefile default and the operator CSV.
- Mirrors the same approach already applied on release-4.18 in https://github.com/red-hat-storage/ceph-csi-operator/pull/222/commits/abea717c1a149e280b00fd8f37925b9730769f12

## Why
`gcr.io/kubebuilder/kube-rbac-proxy` is no longer available after the GCR shutdown. Pulls fail with `manifest unknown`, the kube-rbac-proxy sidecar never starts, and ocs-operator CI on `release-4.17` & 'release-4.18' fails at the ceph-csi-operator install phase with `ImagePullBackOff`.